### PR TITLE
サインインの仕組みを作った

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,23 @@
         overscroll-behavior: none;
       }
 
+      body {
+        font-family: "Helvetica Neue", "Arial", "Hiragino Kaku Gothic ProN",
+          "Hiragino Sans", "Meiryo", sans-serif;
+      }
+
+      input,
+      button,
+      textarea,
+      select {
+        font: inherit;
+      }
+
+      button {
+        height: auto;
+        padding: 6px 16px;
+      }
+
       bg2d-loading {
         width: 50px;
         height: 50px;

--- a/public/index.html
+++ b/public/index.html
@@ -30,33 +30,10 @@
         overscroll-behavior: none;
       }
 
-      .bg2d-loading {
-        display: flex;
-        height: 100%;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .bg2d-loading::before {
-        content: "";
-        display: block;
+      bg2d-loading {
         width: 50px;
         height: 50px;
-        border-radius: 50%;
-        border: 3px solid transparent;
-        border-top-color: currentColor;
-
-        /* https://easings.net/ja#easeInOutQuart */
-        animation: bg2d-spin 1.1s infinite cubic-bezier(0.76, 0, 0.24, 1);
-      }
-
-      @keyframes bg2d-spin {
-        from {
-          transform: rotate(0deg);
-        }
-        to {
-          transform: rotate(360deg);
-        }
+        border-width: 2px;
       }
     </style>
 
@@ -65,7 +42,58 @@
 
   <body>
     <div id="app" style="display: contents;">
-      <div class="bg2d-loading"></div>
+      <div
+        style="
+          display: flex;
+          height: 50%;
+          align-items: center;
+          justify-content: center;
+        "
+      >
+        <bg2d-loading>Loading...</bg2d-loading>
+      </div>
     </div>
+
+    <script>
+      customElements.define(
+        "bg2d-loading",
+        class Loading extends HTMLElement {
+          constructor() {
+            super()
+
+            this.attachShadow({
+              mode: "open",
+            })
+
+            const html = String.raw
+            this.shadowRoot.innerHTML = html`
+              <style>
+                :host {
+                  box-sizing: border-box;
+                  display: inline-block;
+                  width: 1em;
+                  height: 1em;
+                  border-radius: 50%;
+                  border: 1px solid transparent;
+                  border-top-color: currentColor;
+
+                  /* https://easings.net/#easeInOutQuart */
+                  animation: spin 1.1s infinite cubic-bezier(0.76, 0, 0.24, 1);
+                }
+
+                @keyframes spin {
+                  from {
+                    transform: rotate(0deg);
+                  }
+                  to {
+                    transform: rotate(360deg);
+                  }
+                }
+              </style>
+            `
+          }
+        },
+      )
+    </script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { createStore } from "https://cdn.skypack.dev/redux"
 import { AuthGuard, AuthListener, AuthRedirect } from "./auth.js"
 import { Game } from "./Game.js"
 import { Home } from "./Home.js"
+import { Loading } from "./Loading.js"
 import {
   PortalChildrenContainer,
   Provider as PortalProvider,
@@ -36,7 +37,7 @@ export function App() {
             <Route
               path="/sign-in"
               render={() => (
-                <AuthRedirect>
+                <AuthRedirect redirectToDefault="/">
                   <SignIn />
                 </AuthRedirect>
               )}
@@ -49,7 +50,7 @@ export function App() {
                   params: { id },
                 },
               }) => (
-                <AuthGuard>
+                <AuthGuard redirectTo="/sign-in" indeterminate={<Loading />}>
                   <Game id={id} />
                 </AuthGuard>
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Switch,
 } from "https://cdn.skypack.dev/react-router-dom"
 import { createStore } from "https://cdn.skypack.dev/redux"
+import { AuthGuard, AuthRedirect, AuthWatcher } from "./auth.js"
 import { Game } from "./Game.js"
 import { Home } from "./Home.js"
 import {
@@ -23,17 +24,32 @@ export function App() {
 
   return (
     <ReduxProvider store={store}>
+      <AuthWatcher />
+
       <PortalProvider>
         <Router>
           <Switch>
-            <Route exact path="/" render={() => <Home />} />
+            <Route
+              exact
+              path="/"
+              render={() => (
+                <AuthRedirect>
+                  <Home />
+                </AuthRedirect>
+              )}
+            />
+
             <Route
               path="/games/:id"
               render={({
                 match: {
                   params: { id },
                 },
-              }) => <Game id={id} />}
+              }) => (
+                <AuthGuard>
+                  <Game id={id} />
+                </AuthGuard>
+              )}
             />
 
             {/* fallback */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,12 @@ import React, { useMemo } from "https://cdn.skypack.dev/react"
 import { Provider as ReduxProvider } from "https://cdn.skypack.dev/react-redux"
 import {
   BrowserRouter as Router,
+  Link,
   Route,
   Switch,
 } from "https://cdn.skypack.dev/react-router-dom"
 import { createStore } from "https://cdn.skypack.dev/redux"
-import { AuthGuard, AuthRedirect, AuthWatcher } from "./auth.js"
+import { AuthGuard, AuthListener, AuthRedirect } from "./auth.js"
 import { Game } from "./Game.js"
 import { Home } from "./Home.js"
 import {
@@ -14,6 +15,7 @@ import {
   Provider as PortalProvider,
 } from "./Portal.js"
 import { reducer } from "./reducer.js"
+import { SignIn } from "./SignIn.js"
 
 export function App() {
   const store = useMemo(
@@ -24,17 +26,18 @@ export function App() {
 
   return (
     <ReduxProvider store={store}>
-      <AuthWatcher />
+      <AuthListener />
 
       <PortalProvider>
         <Router>
           <Switch>
+            <Route exact path="/" render={() => <Home />} />
+
             <Route
-              exact
-              path="/"
+              path="/sign-in"
               render={() => (
                 <AuthRedirect>
-                  <Home />
+                  <SignIn />
                 </AuthRedirect>
               )}
             />
@@ -73,6 +76,18 @@ function NotFound() {
   return (
     <article>
       <h2>404 Not Found</h2>
+
+      <p>
+        <Link
+          to={{
+            pathname: "/",
+            search: location.search,
+            hash: location.hash,
+          }}
+        >
+          Go to top
+        </Link>
+      </p>
     </article>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
 } from "https://cdn.skypack.dev/react-router-dom"
 import { createStore } from "https://cdn.skypack.dev/redux"
 import { Game } from "./Game.js"
-import { Header } from "./Header.js"
+import { Home } from "./Home.js"
 import {
   PortalChildrenContainer,
   Provider as PortalProvider,
@@ -26,19 +26,7 @@ export function App() {
       <PortalProvider>
         <Router>
           <Switch>
-            <Route
-              exact
-              path="/"
-              render={() => (
-                <div>
-                  <Header />
-
-                  <article>
-                    <h1>Board Game 2D</h1>
-                  </article>
-                </div>
-              )}
-            />
+            <Route exact path="/" render={() => <Home />} />
             <Route
               path="/games/:id"
               render={({

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,46 +1,21 @@
-import { css } from "https://cdn.skypack.dev/emotion"
 import React from "https://cdn.skypack.dev/react"
-import { auth } from "./firebase.js"
+import { Link } from "https://cdn.skypack.dev/react-router-dom"
 
 export function Home() {
   return (
     <article>
       <h1>Board Game 2D</h1>
 
-      <p>Please sign in.</p>
-
-      <p
-        className={css`
-          display: flex;
-          justify-content: center;
-        `}
-      >
-        <button
-          type="button"
-          className={css`
-            display: flex;
-            align-items: center;
-            padding: 8px 16px;
-            height: auto;
-          `}
-          onClick={() => {
-            const provider = new auth.GoogleAuthProvider()
-
-            auth().signInWithRedirect(provider)
+      <p>
+        <Link
+          to={{
+            pathname: "/games/xxx",
+            search: location.search,
+            hash: location.hash,
           }}
         >
-          <img
-            src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
-            width="20"
-            height="20"
-            className={css`
-              float: none;
-              display: inline-block;
-              margin: 0 8px 0 0;
-            `}
-          />
-          Sign in with Google
-        </button>
+          ゲーム開始
+        </Link>
       </p>
     </article>
   )

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,0 +1,11 @@
+import React from "https://cdn.skypack.dev/react"
+
+export function Home() {
+  return (
+    <div>
+      <article>
+        <h1>Board Game 2D</h1>
+      </article>
+    </div>
+  )
+}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,11 +1,47 @@
+import { css } from "https://cdn.skypack.dev/emotion"
 import React from "https://cdn.skypack.dev/react"
+import { auth } from "./firebase.js"
 
 export function Home() {
   return (
-    <div>
-      <article>
-        <h1>Board Game 2D</h1>
-      </article>
-    </div>
+    <article>
+      <h1>Board Game 2D</h1>
+
+      <p>Please sign in.</p>
+
+      <p
+        className={css`
+          display: flex;
+          justify-content: center;
+        `}
+      >
+        <button
+          type="button"
+          className={css`
+            display: flex;
+            align-items: center;
+            padding: 8px 16px;
+            height: auto;
+          `}
+          onClick={() => {
+            const provider = new auth.GoogleAuthProvider()
+
+            auth().signInWithRedirect(provider)
+          }}
+        >
+          <img
+            src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
+            width="20"
+            height="20"
+            className={css`
+              float: none;
+              display: inline-block;
+              margin: 0 8px 0 0;
+            `}
+          />
+          Sign in with Google
+        </button>
+      </p>
+    </article>
   )
 }

--- a/src/Loading.tsx
+++ b/src/Loading.tsx
@@ -1,0 +1,16 @@
+import React from "https://cdn.skypack.dev/react"
+
+export function Loading() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "50%",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <bg2d-loading></bg2d-loading>
+    </div>
+  )
+}

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -22,12 +22,26 @@ export function SignIn() {
             <bg2d-loading />
           </p>
         </>
+      ) : authState === "SIGNED_IN" ? (
+        <>
+          <p></p>
+
+          <p>
+            <Button
+              onClick={() => {
+                auth().signOut()
+              }}
+            >
+              サインアウトする
+            </Button>
+          </p>
+        </>
       ) : (
         <>
           <p>サインインしてください。</p>
 
           <p>
-            <ButtonWithImage
+            <Button
               src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
               onClick={() => {
                 const provider = new auth.GoogleAuthProvider()
@@ -36,7 +50,7 @@ export function SignIn() {
               }}
             >
               Sign in with Google
-            </ButtonWithImage>
+            </Button>
           </p>
         </>
       )}
@@ -44,12 +58,12 @@ export function SignIn() {
   )
 }
 
-function ButtonWithImage({
+function Button({
   src,
   className,
   ...props
 }: {
-  src: string
+  src?: string
   onClick?(): void
   className?: string
   style?: React.CSSProperties
@@ -60,20 +74,23 @@ function ButtonWithImage({
       type="button"
       className={cx(
         css`
-          padding: 8px 16px;
-          height: auto;
-
-          ::before {
-            content: "";
-            display: inline-block;
-            vertical-align: bottom;
-            width: 20px;
-            height: 20px;
-            margin-right: 8px;
-            background-image: url(${src});
-            background-size: contain;
-          }
+          text-align: inherit;
         `,
+        src &&
+          css`
+            ::before {
+              content: "";
+              display: inline-block;
+              vertical-align: -0.14em;
+              width: 1em;
+              height: 1em;
+              margin-right: 8px;
+              background-image: url(${src});
+              background-size: contain;
+              background-repeat: no-repeat;
+              background-position: center;
+            }
+          `,
         className,
       )}
       {...props}

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -1,26 +1,45 @@
 import { css, cx } from "https://cdn.skypack.dev/emotion"
 import React from "https://cdn.skypack.dev/react"
+import { useSelector } from "https://cdn.skypack.dev/react-redux"
 import { auth } from "./firebase.js"
 
 export function SignIn() {
+  const authState = useSelector(state => state.user.auth)
+
   return (
     <article>
       <h1>Board Game 2D</h1>
 
-      <p>サインインしてください。</p>
+      {authState === "CHECKING" ? (
+        <>
+          <p>サインイン中・・・</p>
 
-      <p>
-        <ButtonWithImage
-          src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
-          onClick={() => {
-            const provider = new auth.GoogleAuthProvider()
+          <p
+            className={css`
+              text-align: center;
+            `}
+          >
+            <bg2d-loading />
+          </p>
+        </>
+      ) : (
+        <>
+          <p>サインインしてください。</p>
 
-            auth().signInWithRedirect(provider)
-          }}
-        >
-          Sign in with Google
-        </ButtonWithImage>
-      </p>
+          <p>
+            <ButtonWithImage
+              src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
+              onClick={() => {
+                const provider = new auth.GoogleAuthProvider()
+
+                auth().signInWithRedirect(provider)
+              }}
+            >
+              Sign in with Google
+            </ButtonWithImage>
+          </p>
+        </>
+      )}
     </article>
   )
 }

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -1,10 +1,33 @@
 import { css, cx } from "https://cdn.skypack.dev/emotion"
-import React from "https://cdn.skypack.dev/react"
+import React, { useEffect, useState } from "https://cdn.skypack.dev/react"
 import { useSelector } from "https://cdn.skypack.dev/react-redux"
+import { Redirect } from "https://cdn.skypack.dev/react-router-dom"
 import { auth } from "./firebase.js"
 
 export function SignIn() {
+  const [afterRedirect, setAfterRedirect] = useState(false)
+
+  useEffect(() => {
+    auth()
+      .getRedirectResult()
+      .then(e => {
+        setAfterRedirect(Boolean(e.user))
+      })
+  }, [])
+
   const authState = useSelector(state => state.user.auth)
+
+  if (afterRedirect && authState === "SIGNED_IN") {
+    return (
+      <Redirect
+        to={{
+          pathname: "/",
+          search: location.search,
+          hash: location.hash,
+        }}
+      />
+    )
+  }
 
   return (
     <article>

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -1,0 +1,63 @@
+import { css, cx } from "https://cdn.skypack.dev/emotion"
+import React from "https://cdn.skypack.dev/react"
+import { auth } from "./firebase.js"
+
+export function SignIn() {
+  return (
+    <article>
+      <h1>Board Game 2D</h1>
+
+      <p>サインインしてください。</p>
+
+      <p>
+        <ButtonWithImage
+          src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
+          onClick={() => {
+            const provider = new auth.GoogleAuthProvider()
+
+            auth().signInWithRedirect(provider)
+          }}
+        >
+          Sign in with Google
+        </ButtonWithImage>
+      </p>
+    </article>
+  )
+}
+
+function ButtonWithImage({
+  src,
+  className,
+  ...props
+}: {
+  src: string
+  onClick?(): void
+  className?: string
+  style?: React.CSSProperties
+  children?: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      className={cx(
+        css`
+          padding: 8px 16px;
+          height: auto;
+
+          ::before {
+            content: "";
+            display: inline-block;
+            vertical-align: bottom;
+            width: 20px;
+            height: 20px;
+            margin-right: 8px;
+            background-image: url(${src});
+            background-size: contain;
+          }
+        `,
+        className,
+      )}
+      {...props}
+    ></button>
+  )
+}

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -1,33 +1,10 @@
 import { css, cx } from "https://cdn.skypack.dev/emotion"
-import React, { useEffect, useState } from "https://cdn.skypack.dev/react"
+import React from "https://cdn.skypack.dev/react"
 import { useSelector } from "https://cdn.skypack.dev/react-redux"
-import { Redirect } from "https://cdn.skypack.dev/react-router-dom"
 import { auth } from "./firebase.js"
 
 export function SignIn() {
-  const [afterRedirect, setAfterRedirect] = useState(false)
-
-  useEffect(() => {
-    auth()
-      .getRedirectResult()
-      .then(e => {
-        setAfterRedirect(Boolean(e.user))
-      })
-  }, [])
-
   const authState = useSelector(state => state.user.auth)
-
-  if (afterRedirect && authState === "SIGNED_IN") {
-    return (
-      <Redirect
-        to={{
-          pathname: "/",
-          search: location.search,
-          hash: location.hash,
-        }}
-      />
-    )
-  }
 
   return (
     <article>

--- a/src/achex.tsx
+++ b/src/achex.tsx
@@ -127,6 +127,8 @@ class Achex {
   }
 
   send(data: AchexMessageReq) {
+    if (this.ws.readyState !== WebSocket.OPEN) return
+
     this.ws.send(JSON.stringify(data))
   }
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -7,6 +7,10 @@ export function AuthListener() {
   const dispatch = useDispatch()
 
   useEffect(() => {
+    dispatch({
+      type: "Auth.SignIn.Start",
+    })
+
     return auth().onAuthStateChanged(user => {
       if (user) {
         dispatch({
@@ -27,7 +31,7 @@ export function AuthListener() {
 }
 
 export function AuthGuard({ children }: { children?: React.ReactNode }) {
-  const signedIn = useSelector(state => state.user.signedIn)
+  const signedIn = useSelector(state => state.user.auth === "SIGNED_IN")
 
   if (!signedIn) {
     const search = new URLSearchParams(location.search)
@@ -48,7 +52,7 @@ export function AuthGuard({ children }: { children?: React.ReactNode }) {
 }
 
 export function AuthRedirect({ children }: { children?: React.ReactNode }) {
-  const signedIn = useSelector(state => state.user.signedIn)
+  const signedIn = useSelector(state => state.user.auth === "SIGNED_IN")
 
   const search = new URLSearchParams(location.search)
   if (signedIn && search.has("redirect")) {

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from "https://cdn.skypack.dev/react"
+import { useDispatch, useSelector } from "https://cdn.skypack.dev/react-redux"
+import { Redirect } from "https://cdn.skypack.dev/react-router-dom"
+import { auth } from "./firebase.js"
+
+export function AuthWatcher() {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    return auth().onAuthStateChanged(user => {
+      if (user) {
+        dispatch({
+          type: "Auth.SignIn",
+          payload: {
+            userId: user.uid,
+          },
+        })
+      } else {
+        dispatch({
+          type: "Auth.SignOut",
+        })
+      }
+    })
+  }, [])
+
+  return null
+}
+
+export function AuthGuard({ children }: { children?: React.ReactNode }) {
+  const signedIn = useSelector(state => state.user.signedIn)
+
+  if (!signedIn) {
+    const search = new URLSearchParams(location.search)
+    search.set("redirect", location.pathname)
+
+    return (
+      <Redirect
+        to={{
+          pathname: "/",
+          search: search.toString(),
+          hash: location.hash,
+        }}
+      />
+    )
+  }
+
+  return <>{children}</>
+}
+
+export function AuthRedirect({ children }: { children?: React.ReactNode }) {
+  const signedIn = useSelector(state => state.user.signedIn)
+
+  const search = new URLSearchParams(location.search)
+  if (signedIn && search.has("redirect")) {
+    const redirect = search.get("redirect")
+    search.delete("redirect")
+
+    return (
+      <Redirect
+        to={{
+          pathname: redirect,
+          search: search.toString(),
+          hash: location.hash,
+        }}
+      />
+    )
+  }
+
+  return <>{children}</>
+}

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "https://cdn.skypack.dev/react-redux"
 import { Redirect } from "https://cdn.skypack.dev/react-router-dom"
 import { auth } from "./firebase.js"
 
-export function AuthWatcher() {
+export function AuthListener() {
   const dispatch = useDispatch()
 
   useEffect(() => {
@@ -36,7 +36,7 @@ export function AuthGuard({ children }: { children?: React.ReactNode }) {
     return (
       <Redirect
         to={{
-          pathname: "/",
+          pathname: "/sign-in",
           search: search.toString(),
           hash: location.hash,
         }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "https://cdn.skypack.dev/react"
 import { render } from "https://cdn.skypack.dev/react-dom"
 import { ErrorBoundary } from "./ErrorBoundary.js"
+import { Loading } from "./Loading.js"
 
 const App = React.lazy(() =>
   Promise.all([import("./App.js"), import("./init-app.js")]).then(
@@ -9,21 +10,6 @@ const App = React.lazy(() =>
     }),
   ),
 )
-
-function Loading() {
-  return (
-    <div
-      style={{
-        display: "flex",
-        height: "50%",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <bg2d-loading></bg2d-loading>
-    </div>
-  )
-}
 
 render(
   <ErrorBoundary>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,18 @@ const App = React.lazy(() =>
 )
 
 function Loading() {
-  return <div className="bg2d-loading"></div>
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "50%",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <bg2d-loading></bg2d-loading>
+    </div>
+  )
 }
 
 render(

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -33,6 +33,7 @@ export type State = {
 
 export type User = {
   id: string & { readonly u: unique symbol }
+  signedIn: boolean
 }
 
 export type Game = {
@@ -60,6 +61,7 @@ export type Card = {
 const initialState: State = {
   user: {
     id: randomId() as User["id"],
+    signedIn: false,
   },
   piles: [],
   tempCardPosition: {},
@@ -85,6 +87,15 @@ export type Action =
             }
         )[]
       }
+    }
+  | {
+      type: "Auth.SignIn"
+      payload: {
+        userId: string
+      }
+    }
+  | {
+      type: "Auth.SignOut"
     }
   | {
       type: "Card.DoubleTap"
@@ -185,6 +196,21 @@ export const reducer: Reducer<State, Action> = produce(
             }
           }
         })
+
+        return
+      }
+
+      case "Auth.SignIn": {
+        const { userId } = action.payload
+
+        draft.user.signedIn = true
+        draft.user.id = userId as User["id"]
+
+        return
+      }
+
+      case "Auth.SignOut": {
+        draft.user.signedIn = false
 
         return
       }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -33,7 +33,7 @@ export type State = {
 
 export type User = {
   id: string & { readonly u: unique symbol }
-  signedIn: boolean
+  auth: "INITIAL" | "CHECKING" | "SIGNED_IN" | "SIGNED_OUT"
 }
 
 export type Game = {
@@ -61,7 +61,7 @@ export type Card = {
 const initialState: State = {
   user: {
     id: randomId() as User["id"],
-    signedIn: false,
+    auth: "INITIAL",
   },
   piles: [],
   tempCardPosition: {},
@@ -87,6 +87,9 @@ export type Action =
             }
         )[]
       }
+    }
+  | {
+      type: "Auth.SignIn.Start"
     }
   | {
       type: "Auth.SignIn"
@@ -200,17 +203,23 @@ export const reducer: Reducer<State, Action> = produce(
         return
       }
 
+      case "Auth.SignIn.Start": {
+        draft.user.auth = "CHECKING"
+
+        return
+      }
+
       case "Auth.SignIn": {
         const { userId } = action.payload
 
-        draft.user.signedIn = true
         draft.user.id = userId as User["id"]
+        draft.user.auth = "SIGNED_IN"
 
         return
       }
 
       case "Auth.SignOut": {
-        draft.user.signedIn = false
+        draft.user.auth = "SIGNED_OUT"
 
         return
       }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -2,11 +2,21 @@ import type { Store, Dispatch, StoreEnhancer } from "redux"
 import type { State, Action } from "./reducer"
 
 declare global {
-  declare module "https://*"
+  module "https://*"
 
   interface Window {
     // https://github.com/zalmoxisus/redux-devtools-extension
     __REDUX_DEVTOOLS_EXTENSION__?(): StoreEnhancer
+  }
+
+  namespace JSX {
+    interface IntrinsicElements {
+      "bg2d-loading": {
+        className?: string
+        style?: React.CSSProperties
+        children?: React.ReactNode
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## auth モジュール

認証の諸々をつかさどる。未認証であればパブリックエリアへリダイレクトしたり、認証のリダイレクトフローで戻ってきたときにリダイレクトしたり。

redirect というクエリパラメーターの管理は auth モジュールの責務とし、未認証ならどこへ飛ばすかなどの情報は auth から排除し App モジュールに持たせた。

## そのほか

- 和文と欧文で button の高さが異なるのを是正（modern-css-reset や ress を参考にした）
- ローディングの表示はカスタム要素として実装
  - React 読み込み前から必要になるのと、意外と簡単に作れたため